### PR TITLE
add ->sort() to properly alphabetize collection

### DIFF
--- a/src/Gloss.php
+++ b/src/Gloss.php
@@ -16,7 +16,7 @@ class Gloss {
         }
 
         if ($collection) {
-            $this->collection = $collection;
+            $this->collection = $collection->sort();
         }
         return $this;
     }


### PR DESCRIPTION
The result set I am getting is not sorted correctly in alphabetical order. Add ->sort() method on the $collection property in the createFrom method.
